### PR TITLE
Implement role-based dashboards

### DIFF
--- a/app/Controllers/dashboard_cliente.php
+++ b/app/Controllers/dashboard_cliente.php
@@ -1,1 +1,19 @@
-    
+<?php
+require_once(__DIR__ . '/../../core/AuthMiddleware.php');
+require_once(__DIR__ . '/../../core/functions.php');
+require_once(__DIR__ . '/../Models/ClienteModel.php');
+
+require_auth();
+
+$usuario = current_user();
+if (!$usuario || !in_array($usuario['RolID'], [5, 1])) {
+    header('Location: ' . urlBase('login'));
+    exit;
+}
+
+$cliente = obtenerDatosCliente($usuario['UsuarioID']);
+
+render('cliente/dashboard_cliente', [
+    'usuario' => $usuario,
+    'cliente' => $cliente
+]);

--- a/app/Controllers/dashboard_encargado_inventario.php
+++ b/app/Controllers/dashboard_encargado_inventario.php
@@ -1,0 +1,15 @@
+<?php
+require_once(__DIR__ . '/../../core/AuthMiddleware.php');
+require_once(__DIR__ . '/../../core/functions.php');
+
+require_auth();
+
+$usuario = current_user();
+if (!$usuario || !in_array($usuario['RolID'], [3, 1])) {
+    header('Location: ' . urlBase('login'));
+    exit;
+}
+
+render('encargado_inventario/dashboard_encargado_inventario', [
+    'usuario' => $usuario
+]);

--- a/app/Controllers/dashboard_propietario.php
+++ b/app/Controllers/dashboard_propietario.php
@@ -1,0 +1,15 @@
+<?php
+require_once(__DIR__ . '/../../core/AuthMiddleware.php');
+require_once(__DIR__ . '/../../core/functions.php');
+
+require_auth();
+
+$usuario = current_user();
+if (!$usuario || !in_array($usuario['RolID'], [2, 1])) {
+    header('Location: ' . urlBase('login'));
+    exit;
+}
+
+render('propietario/dashboard_propietario', [
+    'usuario' => $usuario
+]);

--- a/app/Controllers/dashboard_vendedor.php
+++ b/app/Controllers/dashboard_vendedor.php
@@ -1,0 +1,15 @@
+<?php
+require_once(__DIR__ . '/../../core/AuthMiddleware.php');
+require_once(__DIR__ . '/../../core/functions.php');
+
+require_auth();
+
+$usuario = current_user();
+if (!$usuario || !in_array($usuario['RolID'], [4, 1])) {
+    header('Location: ' . urlBase('login'));
+    exit;
+}
+
+render('vendedor/dashboard_vendedor', [
+    'usuario' => $usuario
+]);

--- a/app/Views/encargado_inventario/dashboard_encargado_inventario.php
+++ b/app/Views/encargado_inventario/dashboard_encargado_inventario.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Dashboard Encargado de Inventario</title>
+    <link rel="stylesheet" href="<?= urlBase('assets/main_menu/css/custom.css') ?>">
+</head>
+<body>
+    <h1>Dashboard Encargado de Inventario</h1>
+    <p>Bienvenido, <?= htmlspecialchars($usuario['NombreUsuario']) ?></p>
+</body>
+</html>

--- a/app/Views/propietario/dashboard_propietario.php
+++ b/app/Views/propietario/dashboard_propietario.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Dashboard Propietario</title>
+    <link rel="stylesheet" href="<?= urlBase('assets/main_menu/css/custom.css') ?>">
+</head>
+<body>
+    <h1>Dashboard Propietario</h1>
+    <p>Bienvenido, <?= htmlspecialchars($usuario['NombreUsuario']) ?></p>
+</body>
+</html>

--- a/app/Views/vendedor/dashboard_vendedor.php
+++ b/app/Views/vendedor/dashboard_vendedor.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Dashboard Vendedor</title>
+    <link rel="stylesheet" href="<?= urlBase('assets/main_menu/css/custom.css') ?>">
+</head>
+<body>
+    <h1>Dashboard Vendedor</h1>
+    <p>Bienvenido, <?= htmlspecialchars($usuario['NombreUsuario']) ?></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add controller logic for dashboards of cliente, encargado de inventario, propietario and vendedor
- enforce authentication and role checks using AuthMiddleware
- create basic dashboard views for each role

## Testing
- `php -l app/Controllers/dashboard_cliente.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68463ee0960c832da0f5855cee172039